### PR TITLE
add request url path as endpoint to context

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -31,6 +31,8 @@ const metadataGrpcTimeout = "Grpc-Timeout"
 const xForwardedFor = "X-Forwarded-For"
 const xForwardedHost = "X-Forwarded-Host"
 
+// endpoint is the request URL path that will be used in monitoring metrics collection
+const endpointURLPath = "endpointURLPath"
 var (
 	// DefaultContextTimeout is used for gRPC call context.WithTimeout whenever a Grpc-Timeout inbound
 	// header isn't present. If the value is 0 the sent `context` will not have a timeout.
@@ -83,6 +85,9 @@ func AnnotateContext(ctx context.Context, mux *ServeMux, req *http.Request) (con
 			grpclog.Printf("invalid remote addr: %s", addr)
 		}
 	}
+
+	// include endpoint for creating metrics in monitoring
+	pairs = append(pairs, strings.ToLower(endpointURLPath), req.URL.Path)
 
 	if timeout != 0 {
 		ctx, _ = context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
add request URL path in context for use in monitoring.